### PR TITLE
EROPSPT-None: Add build and push dispatchable workflow

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.DEV2_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DEV2_AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
 
       - name: Login to Amazon ECR

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.DEV2_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DEV2_AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
 
       - name: Run gradle `check` to lint source code and run tests

--- a/.github/workflows/build-tagged-version-and-push-to-ecr.yml
+++ b/.github/workflows/build-tagged-version-and-push-to-ecr.yml
@@ -1,0 +1,12 @@
+name: Build a tagged version and deploy to ECR
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/build-and-push.yml
+    with:
+      version: ${{github.ref_name}}
+    secrets: inherit


### PR DESCRIPTION
This can be useful to deploy a version somewhere for testing, without merging it to main or creating a hotfix branch.
Copied from dwp services.