### PR TITLE
EROPSPT-None: Add index on source reference to certificate and temporary certificate tables

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -37,4 +37,5 @@
     <include relativeToChangelogFile="true" file="ddl/0027_update_aed_summary_view.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0028_alter_aed_contact_details_add_last_updated.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0029_alter_print_request_add_sanitized_surname.xml"/>
+    <include relativeToChangelogFile="true" file="ddl/0030_add_index_for_source_reference_to_certificate_and_temporary_certificate.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0030_add_index_for_source_reference_to_certificate_and_temporary_certificate.xml
+++ b/src/main/resources/db/changelog/ddl/0030_add_index_for_source_reference_to_certificate_and_temporary_certificate.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet id="0030_add_index_for_source_reference_to_certificate_and_temporary_certificate" author="kirsty.land@softwire.com" context="ddl">
+        <createIndex tableName="certificate" indexName="certificate_source_reference_idx">
+            <column name="source_reference"/>
+        </createIndex>
+        <rollback>
+            <dropIndex tableName="certificate" indexName="certificate_source_reference_idx"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="0030_add_index_for_source_reference_to_certificate_and_temporary_certificate" author="kirsty.land@softwire.com" context="ddl">
+        <createIndex tableName="temporary_certificate" indexName="temp_certificate_source_reference_idx">
+            <column name="source_reference"/>
+        </createIndex>
+        <rollback>
+            <dropIndex tableName="temporary_certificate" indexName="temp_certificate_source_reference_idx"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0030_add_index_for_source_reference_to_certificate_and_temporary_certificate.xml
+++ b/src/main/resources/db/changelog/ddl/0030_add_index_for_source_reference_to_certificate_and_temporary_certificate.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
 
-    <changeSet id="0030_add_index_for_source_reference_to_certificate_and_temporary_certificate" author="kirsty.land@softwire.com" context="ddl">
+    <changeSet id="0030a_add_index_for_source_reference_to_certificate" author="kirsty.land@softwire.com" context="ddl">
         <createIndex tableName="certificate" indexName="certificate_source_reference_idx">
             <column name="source_reference"/>
         </createIndex>
@@ -14,7 +14,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet id="0030_add_index_for_source_reference_to_certificate_and_temporary_certificate" author="kirsty.land@softwire.com" context="ddl">
+    <changeSet id="0030b_add_index_for_source_reference_to_temporary_certificate" author="kirsty.land@softwire.com" context="ddl">
         <createIndex tableName="temporary_certificate" indexName="temp_certificate_source_reference_idx">
             <column name="source_reference"/>
         </createIndex>


### PR DESCRIPTION
I suspect this may be the source of the high ACU on the print api tables - the stats endpoints regularly fetches by source reference and source type (without gss code), but the index on the print api table is on (gss_code, source_type, source_reference).