### PR TITLE
EROPSPT-336: Return error and upload response to S3 when temporary VAC too large

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/exception/GlobalExceptionHandler.kt
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_GATEWAY
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.NOT_FOUND
+import org.springframework.http.HttpStatus.PAYLOAD_TOO_LARGE
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
@@ -99,6 +100,21 @@ class GlobalExceptionHandler(
         request: WebRequest
     ): ResponseEntity<Any> {
         return populateErrorResponseAndHandleExceptionInternal(e, BAD_REQUEST, request)
+    }
+
+    /**
+     * Exception handler to return a 413 Payload Too Large ErrorResponse
+     */
+    @ExceptionHandler(
+        value = [
+            ResponseFileTooLargeException::class,
+        ]
+    )
+    protected fun handleExceptionReturnContentTooLargeErrorResponse(
+        e: RuntimeException,
+        request: WebRequest,
+    ): ResponseEntity<Any> {
+        return populateErrorResponseAndHandleExceptionInternal(e, PAYLOAD_TOO_LARGE, request)
     }
 
     /**

--- a/src/main/kotlin/uk/gov/dluhc/printapi/exception/ResponseFileTooLargeException.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/exception/ResponseFileTooLargeException.kt
@@ -1,0 +1,6 @@
+package uk.gov.dluhc.printapi.exception
+
+class ResponseFileTooLargeException : RuntimeException {
+    constructor(eroId: String, documentType: String, sourceReference: String) :
+        super("Response file for eroId = $eroId and sourceReference = $sourceReference too large to generate $documentType")
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/rest/TemporaryCertificateController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rest/TemporaryCertificateController.kt
@@ -96,7 +96,7 @@ class TemporaryCertificateController(
         )
         return temporaryCertificateService.generateTemporaryCertificate(eroId, dto).also {
             if (it.contents.size > MAX_RESPONSE_FILE_SIZE && generateTemporaryCertificateRequest.allowLargeResponse != true) {
-                val s3Path = "temporary_certificates/${dto.gssCode}/${dto.applicationReference}"
+                val s3Path = "temporary_certificates/${dto.gssCode}/${dto.applicationReference}.pdf"
                 logger.warn {
                     "Response file for eroId = $eroId and sourceReference = ${dto.sourceReference} too large " +
                         "to return Temporary VAC - putting to S3 path $s3Path instead"

--- a/src/main/kotlin/uk/gov/dluhc/printapi/rest/TemporaryCertificateController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rest/TemporaryCertificateController.kt
@@ -1,5 +1,6 @@
 package uk.gov.dluhc.printapi.rest
 
+import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.core.io.InputStreamResource
 import org.springframework.http.HttpHeaders
@@ -19,16 +20,20 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.dluhc.printapi.database.entity.SourceType
 import uk.gov.dluhc.printapi.dto.PdfFile
+import uk.gov.dluhc.printapi.exception.ResponseFileTooLargeException
 import uk.gov.dluhc.printapi.mapper.GenerateTemporaryCertificateMapper
 import uk.gov.dluhc.printapi.mapper.TemporaryCertificateSummaryMapper
 import uk.gov.dluhc.printapi.models.GenerateTemporaryCertificateRequest
 import uk.gov.dluhc.printapi.models.TemporaryCertificateSummariesResponse
+import uk.gov.dluhc.printapi.service.S3PhotoService
 import uk.gov.dluhc.printapi.service.StatisticsUpdateService
 import uk.gov.dluhc.printapi.service.pdf.ExplainerPdfService
 import uk.gov.dluhc.printapi.service.temporarycertificate.TemporaryCertificateService
 import uk.gov.dluhc.printapi.service.temporarycertificate.TemporaryCertificateSummaryService
 import java.io.ByteArrayInputStream
 import javax.validation.Valid
+
+private val logger = KotlinLogging.logger {}
 
 @RestController
 @CrossOrigin
@@ -38,8 +43,14 @@ class TemporaryCertificateController(
     @Qualifier("temporaryCertificateExplainerExplainerPdfService") private val explainerPdfService: ExplainerPdfService,
     private val temporaryCertificateService: TemporaryCertificateService,
     private val statisticsUpdateService: StatisticsUpdateService,
+    private val s3Service: S3PhotoService,
     private val generateTemporaryCertificateMapper: GenerateTemporaryCertificateMapper,
 ) {
+
+    companion object {
+        // VAC cannot handle files of 10MB or more
+        const val MAX_RESPONSE_FILE_SIZE = 9 * 1024 * 1024
+    }
 
     @GetMapping("/eros/{eroId}/temporary-certificates")
     @PreAuthorize(HAS_ERO_VC_ADMIN_AUTHORITY)
@@ -84,6 +95,20 @@ class TemporaryCertificateController(
             userId
         )
         return temporaryCertificateService.generateTemporaryCertificate(eroId, dto).also {
+            if (it.contents.size > MAX_RESPONSE_FILE_SIZE && generateTemporaryCertificateRequest.allowLargeResponse != true) {
+                val s3Path = "temporary_certificates/${dto.gssCode}/${dto.applicationReference}"
+                logger.warn {
+                    "Response file for eroId = $eroId and sourceReference = ${dto.sourceReference} too large " +
+                        "to return Temporary VAC - putting to S3 path $s3Path instead"
+                }
+                s3Service.putObjectToTargetBucketFromByteArray(s3Path, it.contents)
+                throw ResponseFileTooLargeException(
+                    eroId,
+                    "Temporary VAC",
+                    dto.sourceReference
+                )
+            }
+        }.also {
             statisticsUpdateService.triggerVoterCardStatisticsUpdate(dto.sourceReference)
         }.let { pdfFile ->
             ResponseEntity.status(CREATED)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/rest/TemporaryCertificateController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rest/TemporaryCertificateController.kt
@@ -96,7 +96,7 @@ class TemporaryCertificateController(
         )
         return temporaryCertificateService.generateTemporaryCertificate(eroId, dto).also {
             if (it.contents.size > MAX_RESPONSE_FILE_SIZE && generateTemporaryCertificateRequest.allowLargeResponse != true) {
-                val s3Path = "temporary_certificates/${dto.gssCode}/${dto.applicationReference}.pdf"
+                val s3Path = "temporary_certificates/${dto.gssCode}/${dto.applicationReference}/${it.filename}"
                 logger.warn {
                     "Response file for eroId = $eroId and sourceReference = ${dto.sourceReference} too large " +
                         "to return Temporary VAC - putting to S3 path $s3Path instead"

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/S3PhotoService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/S3PhotoService.kt
@@ -4,9 +4,11 @@ import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import org.springframework.web.util.UriComponentsBuilder
 import software.amazon.awssdk.core.exception.SdkException
+import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest
@@ -45,6 +47,20 @@ class S3PhotoService(
             }
         } catch (e: SdkException) {
             logger.warn { "Unable to delete photo with S3 arn [$photoS3Arn] due to error [${e.cause?.message ?: e.cause}]" }
+            throw e
+        }
+    }
+
+    fun putObjectToTargetBucketFromByteArray(path: String, data: ByteArray) {
+        var bucket = s3Properties.certificatePhotosTargetBucket
+        try {
+            s3Client.putObject(
+                PutObjectRequest.builder().bucket(bucket).key(path).build(),
+                RequestBody.fromBytes(data)
+            )
+            logger.debug { "Put object to S3 bucket [$bucket] with path [$path]" }
+        } catch (e: SdkException) {
+            logger.warn { "Unable to put object to S3 bucket [$bucket] with path [$path] due to error [${e.cause?.message ?: e.cause}]" }
             throw e
         }
     }

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -1577,6 +1577,8 @@ components:
           format: date
           description: The date that the Temporary Certificate is valid for.
           example: '2023-07-27'
+        allowLargeResponse:
+          type: boolean
       required:
         - gssCode
         - sourceType

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateIntegrationTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.util.ResourceUtils
 import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import uk.gov.dluhc.eromanagementapi.models.LocalAuthorityResponse
 import uk.gov.dluhc.printapi.config.IntegrationTest
@@ -37,7 +38,9 @@ internal class GenerateTemporaryCertificateIntegrationTest : IntegrationTest() {
         private const val GSS_CODE = "W06000023"
         private const val CERTIFICATE_SAMPLE_PHOTO =
             "classpath:temporary-certificate-template/sample-certificate-photo.png"
-        private const val MAX_SIZE_2_MB = 2 * 1024 * 1024
+        private const val LARGE_CERTIFICATE_SAMPLE_PHOTO =
+            "classpath:temporary-certificate-template/sample-too-large-certificate-photo.png"
+        private const val MAX_SIZE_20_MB = 20 * 1024 * 1024
     }
 
     @Test
@@ -171,7 +174,7 @@ internal class GenerateTemporaryCertificateIntegrationTest : IntegrationTest() {
     @Test
     fun `should return temporary certificate pdf given valid request for authorised user`() {
         // Given
-        val photoLocationArn = addPhotoToS3()
+        val photoLocationArn = addPhotoToS3(CERTIFICATE_SAMPLE_PHOTO)
         val request = buildGenerateTemporaryCertificateRequest(photoLocation = photoLocationArn)
         val localAuthorityName = aValidLocalAuthorityName()
         val localAuthorities: List<LocalAuthorityResponse> = listOf(
@@ -186,7 +189,7 @@ internal class GenerateTemporaryCertificateIntegrationTest : IntegrationTest() {
 
         // When
         val response = webTestClient.mutate()
-            .codecs { it.defaultCodecs().maxInMemorySize(MAX_SIZE_2_MB) }
+            .codecs { it.defaultCodecs().maxInMemorySize(MAX_SIZE_20_MB) }
             .build().post()
             .uri(URI_TEMPLATE, ERO_ID)
             .bearerToken(getVCAdminBearerToken(eroId = ERO_ID))
@@ -222,8 +225,108 @@ internal class GenerateTemporaryCertificateIntegrationTest : IntegrationTest() {
         }
     }
 
-    private fun addPhotoToS3(): String {
-        val s3Resource = ResourceUtils.getFile(CERTIFICATE_SAMPLE_PHOTO).readBytes()
+    @Test
+    fun `should return a payload too large error and put the temporary certificate S3 if the file generated is too large`() {
+        // Given
+        val photoLocationArn = addPhotoToS3(LARGE_CERTIFICATE_SAMPLE_PHOTO)
+        val request = buildGenerateTemporaryCertificateRequest(photoLocation = photoLocationArn)
+        val localAuthorityName = aValidLocalAuthorityName()
+        val localAuthorities: List<LocalAuthorityResponse> = listOf(
+            buildLocalAuthorityResponse(
+                gssCode = request.gssCode,
+                contactDetailsEnglish = buildContactDetails(nameVac = localAuthorityName)
+            )
+        )
+        val eroResponse = buildElectoralRegistrationOfficeResponse(id = ERO_ID, localAuthorities = localAuthorities)
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByGssCode(eroResponse, request.gssCode)
+
+        // When
+        val response = webTestClient.mutate()
+            .codecs { it.defaultCodecs().maxInMemorySize(MAX_SIZE_20_MB) }
+            .build().post()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .bearerToken(getVCAdminBearerToken(eroId = ERO_ID))
+            .contentType(MediaType.APPLICATION_JSON)
+            .withBody(request)
+            .exchange()
+            .expectStatus()
+            .isEqualTo(413)
+            .returnResult(ErrorResponse::class.java)
+
+        // Then
+        val actual = response.responseBody.blockFirst()
+        assertThat(actual)
+            .hasStatus(413)
+            .hasError("Payload Too Large")
+            .hasMessageContaining("Response file for eroId = $ERO_ID and sourceReference = ${request.sourceReference} too large to generate Temporary VAC")
+
+        val temporaryCertificateInS3 =
+            getObjectFromS3("temporary_certificates/${request.gssCode}/${request.applicationReference}")
+        assertThat(temporaryCertificateInS3).hasSizeGreaterThan(9 * 1024 * 1024)
+        PdfReader(temporaryCertificateInS3).use { reader ->
+            val text = PdfTextExtractor(reader).getTextFromPage(1)
+            assertThat(text).contains(localAuthorityName)
+        }
+    }
+
+    @Test
+    fun `should return temporary certificate pdf given large file and allowLargeResponse flag`() {
+        // Given
+        val photoLocationArn = addPhotoToS3(LARGE_CERTIFICATE_SAMPLE_PHOTO)
+        val request =
+            buildGenerateTemporaryCertificateRequest(photoLocation = photoLocationArn, allowLargeResponse = true)
+        val localAuthorityName = aValidLocalAuthorityName()
+        val localAuthorities: List<LocalAuthorityResponse> = listOf(
+            buildLocalAuthorityResponse(
+                gssCode = request.gssCode,
+                contactDetailsEnglish = buildContactDetails(nameVac = localAuthorityName)
+            )
+        )
+        val eroResponse = buildElectoralRegistrationOfficeResponse(id = ERO_ID, localAuthorities = localAuthorities)
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByGssCode(eroResponse, request.gssCode)
+
+        // When
+        val response = webTestClient.mutate()
+            .codecs { it.defaultCodecs().maxInMemorySize(MAX_SIZE_20_MB) }
+            .build().post()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .bearerToken(getVCAdminBearerToken(eroId = ERO_ID))
+            .contentType(MediaType.APPLICATION_JSON)
+            .withBody(request)
+            .exchange()
+            .expectStatus().isCreated
+            .expectHeader().contentType(MediaType.APPLICATION_PDF)
+            .expectBody(ByteArray::class.java)
+            .returnResult()
+
+        // Then
+        val temporaryCertificates = temporaryCertificateRepository.findByGssCodeInAndSourceTypeAndSourceReference(
+            listOf(request.gssCode),
+            VOTER_CARD,
+            request.sourceReference
+        )
+        assertThat(temporaryCertificates).hasSize(1)
+        val temporaryCertificate = temporaryCertificates[0]
+        val contentDisposition = response.responseHeaders.contentDisposition
+        assertThat(contentDisposition.filename)
+            .isEqualTo("temporary-certificate-${temporaryCertificate.certificateNumber}.pdf")
+
+        val pdfContent = response.responseBody
+        assertThat(pdfContent).isNotNull
+        PdfReader(pdfContent).use { reader ->
+            val text = PdfTextExtractor(reader).getTextFromPage(1)
+            assertThat(text).contains(localAuthorityName)
+        }
+
+        await.atMost(5, TimeUnit.SECONDS).untilAsserted {
+            assertUpdateStatisticsMessageSent(request.sourceReference)
+        }
+    }
+
+    private fun addPhotoToS3(filepath: String): String {
+        val s3Resource = ResourceUtils.getFile(filepath).readBytes()
         val s3Bucket = LocalStackContainerConfiguration.S3_BUCKET_CONTAINING_PHOTOS
         val s3Path = "E09000007/0013a30ac9bae2ebb9b1239b/${UUID.randomUUID()}/8a53a30ac9bae2ebb9b1239b-test-photo.png"
 
@@ -236,5 +339,13 @@ internal class GenerateTemporaryCertificateIntegrationTest : IntegrationTest() {
             RequestBody.fromInputStream(ByteArrayInputStream(s3Resource), s3Resource.size.toLong())
         )
         return "arn:aws:s3:::$s3Bucket/$s3Path"
+    }
+
+    private fun getObjectFromS3(s3Path: String): ByteArray {
+        val s3Bucket = LocalStackContainerConfiguration.S3_BUCKET_CONTAINING_PHOTOS
+
+        return s3Client.getObjectAsBytes(
+            GetObjectRequest.builder().bucket(s3Bucket).key(s3Path).build()
+        ).asByteArray()
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateIntegrationTest.kt
@@ -262,7 +262,7 @@ internal class GenerateTemporaryCertificateIntegrationTest : IntegrationTest() {
             .hasMessageContaining("Response file for eroId = $ERO_ID and sourceReference = ${request.sourceReference} too large to generate Temporary VAC")
 
         val temporaryCertificateInS3 =
-            getObjectFromS3("temporary_certificates/${request.gssCode}/${request.applicationReference}")
+            getObjectFromS3("temporary_certificates/${request.gssCode}/${request.applicationReference}.pdf")
         assertThat(temporaryCertificateInS3).hasSizeGreaterThan(9 * 1024 * 1024)
         PdfReader(temporaryCertificateInS3).use { reader ->
             val text = PdfTextExtractor(reader).getTextFromPage(1)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateIntegrationTest.kt
@@ -261,8 +261,16 @@ internal class GenerateTemporaryCertificateIntegrationTest : IntegrationTest() {
             .hasError("Payload Too Large")
             .hasMessageContaining("Response file for eroId = $ERO_ID and sourceReference = ${request.sourceReference} too large to generate Temporary VAC")
 
+        val temporaryCertificates = temporaryCertificateRepository.findByGssCodeInAndSourceTypeAndSourceReference(
+            listOf(request.gssCode),
+            VOTER_CARD,
+            request.sourceReference
+        )
+        assertThat(temporaryCertificates).hasSize(1)
+        val temporaryCertificate = temporaryCertificates[0]
+
         val temporaryCertificateInS3 =
-            getObjectFromS3("temporary_certificates/${request.gssCode}/${request.applicationReference}.pdf")
+            getObjectFromS3("temporary_certificates/${request.gssCode}/${request.applicationReference}/temporary-certificate-${temporaryCertificate.certificateNumber}.pdf")
         assertThat(temporaryCertificateInS3).hasSizeGreaterThan(9 * 1024 * 1024)
         PdfReader(temporaryCertificateInS3).use { reader ->
             val text = PdfTextExtractor(reader).getTextFromPage(1)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/GenerateTemporaryCertificateRequestBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/GenerateTemporaryCertificateRequestBuilder.kt
@@ -23,6 +23,7 @@ fun buildGenerateTemporaryCertificateRequest(
     certificateLanguage: CertificateLanguage = CertificateLanguage.EN,
     photoLocation: String = aPhotoArn(),
     validOnDate: LocalDate = aValidIssueDate(),
+    allowLargeResponse: Boolean? = null,
 ): GenerateTemporaryCertificateRequest =
     GenerateTemporaryCertificateRequest(
         gssCode = gssCode,
@@ -34,5 +35,6 @@ fun buildGenerateTemporaryCertificateRequest(
         surname = surname,
         certificateLanguage = certificateLanguage,
         photoLocation = photoLocation,
-        validOnDate = validOnDate
+        validOnDate = validOnDate,
+        allowLargeResponse = allowLargeResponse,
     )


### PR DESCRIPTION
I don't know if either or both these changes would be worth doing or would be likely to be approved for release:

- Not returning anything more than 9MB should stop VAC from getting stuck hopefully - this seems sensible
- Uploading any temporary certificates that are too big to S3 would make it much easier for us to access them - we'd want to revert this change after Enhanced Support ends and clear out this folder in S3. This seems more risky and would require giving print api write permissions to the bucket, but derisks having to send temporary certificates over until Thursday - otherwise I'm not sure whether we'll be able to keep up with the workload.