### PR TITLE
EROPSPT-335: Turn off storing temporary certificates in S3

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/rest/TemporaryCertificateController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rest/TemporaryCertificateController.kt
@@ -2,6 +2,7 @@ package uk.gov.dluhc.printapi.rest
 
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.io.InputStreamResource
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpHeaders.CONTENT_DISPOSITION
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.dluhc.printapi.database.entity.SourceType
+import uk.gov.dluhc.printapi.dto.GenerateTemporaryCertificateDto
 import uk.gov.dluhc.printapi.dto.PdfFile
 import uk.gov.dluhc.printapi.exception.ResponseFileTooLargeException
 import uk.gov.dluhc.printapi.mapper.GenerateTemporaryCertificateMapper
@@ -45,6 +47,7 @@ class TemporaryCertificateController(
     private val statisticsUpdateService: StatisticsUpdateService,
     private val s3Service: S3PhotoService,
     private val generateTemporaryCertificateMapper: GenerateTemporaryCertificateMapper,
+    @Value("\${api.print-api.generate-temporary-certificate.upload-large-file-to-s3}") private val uploadLargeFileToS3: Boolean,
 ) {
 
     companion object {
@@ -96,17 +99,7 @@ class TemporaryCertificateController(
         )
         return temporaryCertificateService.generateTemporaryCertificate(eroId, dto).also {
             if (it.contents.size > MAX_RESPONSE_FILE_SIZE && generateTemporaryCertificateRequest.allowLargeResponse != true) {
-                val s3Path = "temporary_certificates/${dto.gssCode}/${dto.applicationReference}/${it.filename}"
-                logger.warn {
-                    "Response file for eroId = $eroId and sourceReference = ${dto.sourceReference} too large " +
-                        "to return Temporary VAC - putting to S3 path $s3Path instead"
-                }
-                s3Service.putObjectToTargetBucketFromByteArray(s3Path, it.contents)
-                throw ResponseFileTooLargeException(
-                    eroId,
-                    "Temporary VAC",
-                    dto.sourceReference
-                )
+                handleResponseFileTooLarge(it, eroId, dto)
             }
         }.also {
             statisticsUpdateService.triggerVoterCardStatisticsUpdate(dto.sourceReference)
@@ -138,5 +131,28 @@ class TemporaryCertificateController(
         headers.contentType = APPLICATION_PDF
         headers.add(CONTENT_DISPOSITION, "inline; filename=${pdfFile.filename}")
         return headers
+    }
+
+    private fun handleResponseFileTooLarge(pdfFile: PdfFile, eroId: String, dto: GenerateTemporaryCertificateDto) {
+        logger.warn {
+            "Response file for eroId = $eroId and sourceReference = ${dto.sourceReference} too large to return Temporary VAC"
+        }
+        if (uploadLargeFileToS3) {
+            val s3Path = "temporary_certificates/${dto.gssCode}/${dto.applicationReference}/${pdfFile.filename}"
+            logger.warn {
+                "Uploaded Temporary Certificate for ${dto.sourceReference} to S3 path $s3Path"
+            }
+            s3Service.putObjectToTargetBucketFromByteArray(s3Path, pdfFile.contents)
+        } else {
+            logger.warn {
+                "Not uploading Temporary Certificate for ${dto.sourceReference} to S3 path"
+            }
+        }
+
+        throw ResponseFileTooLargeException(
+            eroId,
+            "Temporary VAC",
+            dto.sourceReference
+        )
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,7 @@ api:
     generate-temporary-certificate:
       valid-on-date:
         max-calendar-days-in-future: 30
+      upload-large-file-to-s3: false
     data-retention:
       # The legislation defines the first (initial) retention period as 28 working days from the date of "issue", which has been confirmed as the date the
       # certificate was printed, not when it was sent to the print provider (and therefore not the "issue date" that is currently printed on the certificate

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -40,6 +40,8 @@ s3:
 api:
   print-api:
     base.url: http://localhost:8080
+    generate-temporary-certificate:
+      upload-large-file-to-s3: true
   ero-management:
     url: http://will-be-replaced-by-wireMockServer-bean
 


### PR DESCRIPTION
This was added over the final few days before the general election, to make it easy to retrieve any certificates affected by this issue.

In the short term, it is unlikely that many temporary certificates will be generated after the election, and turning this off means we don't need to remember to manually ensure the data is not retained for longer than it should be. We have a workaround for generating and retrieving a certificate if required, even if this feature is turned off.

In the longer term, we are looking for improvements to ensure large Temporary Certificates can be downloaded.

After releasing this change, we should check the temporary_certificates folder in the live-vca-api-vca-target-bucket is empty, and remove any PDFs in this folder.