### PR TITLE
EROPSPT-396: Reset initial removal date when reissuing AED

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/aed/ReIssueAnonymousElectorDocumentMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/aed/ReIssueAnonymousElectorDocumentMapper.kt
@@ -10,6 +10,7 @@ import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocumentStatus
 import uk.gov.dluhc.printapi.dto.aed.ReIssueAnonymousElectorDocumentDto
 import uk.gov.dluhc.printapi.mapper.DeliveryAddressTypeMapper
 import uk.gov.dluhc.printapi.models.ReIssueAnonymousElectorDocumentRequest
+import uk.gov.dluhc.printapi.service.ElectorDocumentRemovalDateResolver
 import uk.gov.dluhc.printapi.service.IdFactory
 
 @Mapper(
@@ -30,6 +31,9 @@ abstract class ReIssueAnonymousElectorDocumentMapper {
 
     @Autowired
     protected lateinit var deliveryAddressTypeMapper: DeliveryAddressTypeMapper
+
+    @Autowired
+    protected lateinit var removalDateResolver: ElectorDocumentRemovalDateResolver
 
     abstract fun toReIssueAnonymousElectorDocumentDto(
         apiRequest: ReIssueAnonymousElectorDocumentRequest,
@@ -77,5 +81,15 @@ abstract class ReIssueAnonymousElectorDocumentMapper {
         dto: ReIssueAnonymousElectorDocumentDto,
     ) {
         aed.delivery?.deliveryAddressType = deliveryAddressTypeMapper.mapDtoToEntity(dto.deliveryAddressType)
+    }
+
+    @AfterMapping
+    protected fun setDataRetentionDates(
+        @MappingTarget aed: AnonymousElectorDocument,
+        previousAed: AnonymousElectorDocument
+    ) {
+        if (previousAed.initialRetentionRemovalDate != null) {
+            aed.initialRetentionRemovalDate = removalDateResolver.getAedInitialRetentionPeriodRemovalDate(aed.issueDate)
+        }
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/ReIssueAnonymousElectorDocumentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/ReIssueAnonymousElectorDocumentIntegrationTest.kt
@@ -28,6 +28,7 @@ import uk.gov.dluhc.printapi.testsupport.testdata.model.buildLocalAuthorityRespo
 import uk.gov.dluhc.printapi.testsupport.testdata.model.buildReIssueAnonymousElectorDocumentRequest
 import uk.gov.dluhc.printapi.testsupport.withBody
 import java.io.ByteArrayInputStream
+import java.time.LocalDate
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
@@ -197,6 +198,131 @@ internal class ReIssueAnonymousElectorDocumentIntegrationTest : IntegrationTest(
         await.pollDelay(3, TimeUnit.SECONDS).untilAsserted {
             assertUpdateStatisticsMessageNotSent()
         }
+    }
+
+    @Test
+    fun `should set initial data retention date for new AED given previously issued AED has initial data retention date set`() {
+        // Given
+        val eroResponse = buildElectoralRegistrationOfficeResponse(
+            id = ERO_ID,
+            localAuthorities = listOf(buildLocalAuthorityResponse(gssCode = GSS_CODE), buildLocalAuthorityResponse())
+        )
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByEroId(eroResponse, ERO_ID)
+
+        val sourceReference = aValidSourceReference()
+        val photoLocationArn = addPhotoToS3()
+        val originalRetentionRemovalDate = LocalDate.now().minusMonths(4)
+
+        val originalElectoralRollNumber = "ORIGINAL ELECTORAL ROLL #"
+        val previousAed = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            sourceReference = sourceReference,
+            photoLocationArn = photoLocationArn,
+            electoralRollNumber = originalElectoralRollNumber,
+            initialRetentionRemovalDate = originalRetentionRemovalDate,
+        )
+        anonymousElectorDocumentRepository.save(previousAed)
+
+        val newElectoralRollNumber = aValidElectoralRollNumber()
+        val requestBody = buildReIssueAnonymousElectorDocumentRequest(
+            sourceReference = sourceReference,
+            electoralRollNumber = newElectoralRollNumber,
+        )
+
+        // When
+        val response = webTestClient.mutate()
+            .codecs { it.defaultCodecs().maxInMemorySize(MAX_SIZE_2_MB) }
+            .build()
+            .post()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .bearerToken(getVCAnonymousAdminBearerToken(eroId = ERO_ID))
+            .contentType(APPLICATION_JSON)
+            .withBody(requestBody)
+            .exchange()
+            .expectStatus().isCreated
+            .expectHeader().contentType(MediaType.APPLICATION_PDF)
+            .expectBody(ByteArray::class.java)
+            .returnResult()
+
+        // Then
+        val contentDisposition = response.responseHeaders.contentDisposition
+
+        val electorDocuments = anonymousElectorDocumentRepository.findByGssCodeAndSourceTypeAndSourceReference(
+            GSS_CODE,
+            ANONYMOUS_ELECTOR_DOCUMENT,
+            sourceReference
+        )
+
+        // Get the new AED that this test would have created
+        val newlyCreatedAed = electorDocuments.first { aed ->
+            contentDisposition.filename == "anonymous-elector-document-${aed.certificateNumber}.pdf"
+        }
+
+        val expectedNewRetentionDate = LocalDate.now().plusMonths(15)
+        assertThat(newlyCreatedAed)
+            .hasInitialRetentionRemovalDate(expectedNewRetentionDate)
+    }
+
+    @Test
+    fun `should not set initial data retention date for new AED given previously issued AED does not have the initial data retention date set`() {
+        // Given
+        val eroResponse = buildElectoralRegistrationOfficeResponse(
+            id = ERO_ID,
+            localAuthorities = listOf(buildLocalAuthorityResponse(gssCode = GSS_CODE), buildLocalAuthorityResponse())
+        )
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByEroId(eroResponse, ERO_ID)
+
+        val sourceReference = aValidSourceReference()
+        val photoLocationArn = addPhotoToS3()
+
+        val originalElectoralRollNumber = "ORIGINAL ELECTORAL ROLL #"
+        val previousAed = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            sourceReference = sourceReference,
+            photoLocationArn = photoLocationArn,
+            electoralRollNumber = originalElectoralRollNumber,
+            initialRetentionRemovalDate = null,
+        )
+        anonymousElectorDocumentRepository.save(previousAed)
+
+        val newElectoralRollNumber = aValidElectoralRollNumber()
+        val requestBody = buildReIssueAnonymousElectorDocumentRequest(
+            sourceReference = sourceReference,
+            electoralRollNumber = newElectoralRollNumber,
+        )
+
+        // When
+        val response = webTestClient.mutate()
+            .codecs { it.defaultCodecs().maxInMemorySize(MAX_SIZE_2_MB) }
+            .build()
+            .post()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .bearerToken(getVCAnonymousAdminBearerToken(eroId = ERO_ID))
+            .contentType(APPLICATION_JSON)
+            .withBody(requestBody)
+            .exchange()
+            .expectStatus().isCreated
+            .expectHeader().contentType(MediaType.APPLICATION_PDF)
+            .expectBody(ByteArray::class.java)
+            .returnResult()
+
+        // Then
+        val contentDisposition = response.responseHeaders.contentDisposition
+
+        val electorDocuments = anonymousElectorDocumentRepository.findByGssCodeAndSourceTypeAndSourceReference(
+            GSS_CODE,
+            ANONYMOUS_ELECTOR_DOCUMENT,
+            sourceReference
+        )
+
+        // Get the new AED that this test would have created
+        val newlyCreatedAed = electorDocuments.first { aed ->
+            contentDisposition.filename == "anonymous-elector-document-${aed.certificateNumber}.pdf"
+        }
+
+        assertThat(newlyCreatedAed).hasInitialRetentionRemovalDate(null)
     }
 
     private fun addPhotoToS3(): String {


### PR DESCRIPTION
I haven't covered the final data retention date here, only the initial date.

~Having had a call with policy, it is no longer clear whether this date should be reset, so I've made the PR into a draft and will hold off merging until we have more clarity.~
Following further calls with policy, we will be going ahead with this change.