### PR TITLE
EROPSPT-405: Exclude AEDs from endpoints once past initial data retention

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentRepository.kt
@@ -12,9 +12,7 @@ interface AnonymousElectorDocumentRepository : JpaRepository<AnonymousElectorDoc
 
     fun findByGssCodeAndSourceTypeAndSourceReference(gssCode: String, sourceType: SourceType, sourceReference: String): List<AnonymousElectorDocument>
 
-    fun findByGssCodeInAndSourceTypeAndSourceReference(gssCodes: List<String>, sourceType: SourceType, sourceReference: String): List<AnonymousElectorDocument>
-
-    fun findBySourceTypeAndSourceReference(sourceType: SourceType, sourceReference: String): List<AnonymousElectorDocument>
+    fun findByGssCodeInAndSourceTypeAndSourceReferenceAndInitialRetentionDataRemoved(gssCodes: List<String>, sourceType: SourceType, sourceReference: String, initialRetentionDataRemoved: Boolean): List<AnonymousElectorDocument>
 
     fun findBySourceTypeAndInitialRetentionDataRemovedAndInitialRetentionRemovalDateBefore(
         sourceType: SourceType,

--- a/src/main/kotlin/uk/gov/dluhc/printapi/rest/aed/AnonymousElectorDocumentController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rest/aed/AnonymousElectorDocumentController.kt
@@ -116,7 +116,7 @@ class AnonymousElectorDocumentController(
         authentication: Authentication
     ) {
         updateRequest.validate()
-        anonymousElectorDocumentService.updateAnonymousElectorDocument(
+        anonymousElectorDocumentService.updateFullyRetainedAnonymousElectorDocuments(
             eroId, updateAnonymousElectorDocumentMapper.toUpdateAedDto(updateRequest)
         )
     }
@@ -129,7 +129,7 @@ class AnonymousElectorDocumentController(
         @RequestParam applicationId: String,
     ): AnonymousElectorDocumentsResponse {
         val anonymousElectorDocuments = anonymousElectorDocumentService
-            .getAnonymousElectorDocuments(eroId, applicationId)
+            .getFullyRetainedAnonymousElectorDocuments(eroId, applicationId)
             .map { anonymousElectorDocumentMapper.mapToApiAnonymousElectorDocument(it, eroId) }
         return AnonymousElectorDocumentsResponse(anonymousElectorDocuments = anonymousElectorDocuments)
     }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/rest/aed/AnonymousElectorDocumentPhotoController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rest/aed/AnonymousElectorDocumentPhotoController.kt
@@ -32,7 +32,7 @@ class AnonymousElectorDocumentPhotoController(
         @RequestParam applicationId: String,
     ): PreSignedUrlResourceResponse {
         val aed = anonymousElectorDocumentService
-            .getAnonymousElectorDocuments(eroId, applicationId)
+            .getFullyRetainedAnonymousElectorDocuments(eroId, applicationId)
             .firstOrNull() ?: throw CertificateNotFoundException(eroId, ANONYMOUS_ELECTOR_DOCUMENT, applicationId)
 
         val preSignedUrl = s3AccessService.generatePresignedGetCertificatePhotoUrl(aed.photoLocationArn)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
@@ -46,6 +46,7 @@ import uk.gov.dluhc.printapi.messaging.models.ProcessPrintResponseFileMessage
 import uk.gov.dluhc.printapi.messaging.models.ProcessPrintResponseMessage
 import uk.gov.dluhc.printapi.messaging.models.RemoveCertificateMessage
 import uk.gov.dluhc.printapi.messaging.stubs.UpdateStatisticsMessageListenerStub
+import uk.gov.dluhc.printapi.service.AedDataRetentionService
 import uk.gov.dluhc.printapi.service.BankHolidaysDataService
 import uk.gov.dluhc.printapi.service.CertificateSummarySearchService
 import uk.gov.dluhc.printapi.service.SftpService
@@ -175,6 +176,9 @@ internal abstract class IntegrationTest {
 
     @Autowired
     protected lateinit var bankHolidaysDataService: BankHolidaysDataService
+
+    @Autowired
+    protected lateinit var aedDataRetentionService: AedDataRetentionService
 
     @Autowired
     protected lateinit var cacheManager: CacheManager

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/GetAnonymousElectorDocumentsPhotoByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/GetAnonymousElectorDocumentsPhotoByApplicationIdIntegrationTest.kt
@@ -21,7 +21,8 @@ import uk.gov.dluhc.printapi.testsupport.testdata.zip.aPhotoBucketPath
 
 internal class GetAnonymousElectorDocumentsPhotoByApplicationIdIntegrationTest : IntegrationTest() {
     companion object {
-        private const val URI_TEMPLATE = "/eros/{ERO_ID}/anonymous-elector-documents/photo?applicationId={APPLICATION_ID}"
+        private const val URI_TEMPLATE =
+            "/eros/{ERO_ID}/anonymous-elector-documents/photo?applicationId={APPLICATION_ID}"
         private const val APPLICATION_ID = "6407b6158f529a11713a1e5c"
         private const val GSS_CODE = "W06000099"
     }
@@ -102,7 +103,6 @@ internal class GetAnonymousElectorDocumentsPhotoByApplicationIdIntegrationTest :
         anonymousElectorDocumentRepository.save(anonymousElectorDocument1)
         s3Client.addCertificatePhotoToS3(s3Bucket, s3PathAedPhoto1)
 
-
         // When
         val response = webTestClient.get()
             .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
@@ -120,7 +120,6 @@ internal class GetAnonymousElectorDocumentsPhotoByApplicationIdIntegrationTest :
             .hasError("Not Found")
             .hasMessage("Certificate for eroId = $ERO_ID with sourceType = ANONYMOUS_ELECTOR_DOCUMENT and sourceReference = $APPLICATION_ID not found")
     }
-
 
     @Test
     fun `should return a presigned url for the AED photo`() {
@@ -206,7 +205,6 @@ internal class GetAnonymousElectorDocumentsPhotoByApplicationIdIntegrationTest :
         }
     }
 
-
     @Test
     fun `should return a presigned url for the AED photo given object key contains special characters`() {
         // Given
@@ -225,7 +223,8 @@ internal class GetAnonymousElectorDocumentsPhotoByApplicationIdIntegrationTest :
         )
         anonymousElectorDocumentRepository.save(anonymousElectorDocument1)
         s3Client.addCertificatePhotoToS3(s3Bucket, photoObjectKey)
-        val expectedEncodedPath = "dir1/Jane%2B%21%40%C2%A3%24%25%5E%26%2A%28%29%29%29%29_%2B-%3D%5B%5D%7B%7D%27%5C%7C%3B%3B%3C%3E%2C.%3A%3F%23%60~%C2%A7%C2%B1%20Doe%3AAwesome%20Company%20Ltd%3AHEADSHOT.jpg"
+        val expectedEncodedPath =
+            "dir1/Jane%2B%21%40%C2%A3%24%25%5E%26%2A%28%29%29%29%29_%2B-%3D%5B%5D%7B%7D%27%5C%7C%3B%3B%3C%3E%2C.%3A%3F%23%60~%C2%A7%C2%B1%20Doe%3AAwesome%20Company%20Ltd%3AHEADSHOT.jpg"
 
         // When
         val response = webTestClient.get()

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/ReIssueAnonymousElectorDocumentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/ReIssueAnonymousElectorDocumentIntegrationTest.kt
@@ -297,9 +297,9 @@ internal class ReIssueAnonymousElectorDocumentIntegrationTest : IntegrationTest(
             sourceReference
         )
         assertThat(electorDocuments)
-            .hasSize(2) // Exactly 2 AEDs expected in the database for this sourceReference
+            .hasSize(3) // Exactly 3 AEDs expected in the database for this sourceReference (one removed, one previous and one reissue)
             .anyMatch { aed ->
-                // Of the 2 AEDs in the database the response PDF filename will match only one of them.
+                // Of the 3 AEDs in the database the response PDF filename will match only one of them.
                 contentDisposition.filename == "anonymous-elector-document-${aed.certificateNumber}.pdf"
             }
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/ReIssueAnonymousElectorDocumentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/ReIssueAnonymousElectorDocumentIntegrationTest.kt
@@ -119,6 +119,42 @@ internal class ReIssueAnonymousElectorDocumentIntegrationTest : IntegrationTest(
     }
 
     @Test
+    fun `should return not found given AED has initial retention period data deleted`() {
+        // Given
+        val eroResponse = buildElectoralRegistrationOfficeResponse(
+            id = ERO_ID,
+            localAuthorities = listOf(buildLocalAuthorityResponse(gssCode = GSS_CODE), buildLocalAuthorityResponse())
+        )
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByEroId(eroResponse, ERO_ID)
+
+        val previousAed = buildAnonymousElectorDocument(gssCode = GSS_CODE)
+        previousAed.removeInitialRetentionPeriodData()
+        anonymousElectorDocumentRepository.save(previousAed)
+        val requestBody = buildReIssueAnonymousElectorDocumentRequest(
+            sourceReference = previousAed.sourceReference
+        )
+
+        // When
+        val response = webTestClient.post()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .bearerToken(getVCAnonymousAdminBearerToken(eroId = ERO_ID))
+            .contentType(APPLICATION_JSON)
+            .withBody(requestBody)
+            .exchange()
+            .expectStatus()
+            .isNotFound
+            .returnResult(ErrorResponse::class.java)
+
+        // Then
+        val actual = response.responseBody.blockFirst()
+        assertThat(actual)
+            .hasStatus(404)
+            .hasError("Not Found")
+            .hasMessage("Certificate for eroId = $ERO_ID with sourceType = ANONYMOUS_ELECTOR_DOCUMENT and sourceReference = ${previousAed.sourceReference} not found")
+    }
+
+    @Test
     fun `should return AED PDF given specified application has previously issued AED`() {
         // Given
         val eroResponse = buildElectoralRegistrationOfficeResponse(
@@ -139,6 +175,96 @@ internal class ReIssueAnonymousElectorDocumentIntegrationTest : IntegrationTest(
             electoralRollNumber = originalElectoralRollNumber,
         )
         anonymousElectorDocumentRepository.save(previousAed)
+
+        val newElectoralRollNumber = aValidElectoralRollNumber()
+        val requestBody = buildReIssueAnonymousElectorDocumentRequest(
+            sourceReference = sourceReference,
+            electoralRollNumber = newElectoralRollNumber,
+        )
+
+        // When
+        val response = webTestClient.mutate()
+            .codecs { it.defaultCodecs().maxInMemorySize(MAX_SIZE_2_MB) }
+            .build()
+            .post()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .bearerToken(getVCAnonymousAdminBearerToken(eroId = ERO_ID))
+            .contentType(APPLICATION_JSON)
+            .withBody(requestBody)
+            .exchange()
+            .expectStatus().isCreated
+            .expectHeader().contentType(MediaType.APPLICATION_PDF)
+            .expectBody(ByteArray::class.java)
+            .returnResult()
+
+        // Then
+        val pdfContent = response.responseBody
+        val contentDisposition = response.responseHeaders.contentDisposition
+
+        val electorDocuments = anonymousElectorDocumentRepository.findByGssCodeAndSourceTypeAndSourceReference(
+            GSS_CODE,
+            ANONYMOUS_ELECTOR_DOCUMENT,
+            sourceReference
+        )
+        assertThat(electorDocuments)
+            .hasSize(2) // Exactly 2 AEDs expected in the database for this sourceReference
+            .anyMatch { aed ->
+                // Of the 2 AEDs in the database the response PDF filename will match only one of them.
+                contentDisposition.filename == "anonymous-elector-document-${aed.certificateNumber}.pdf"
+            }
+
+        val newlyCreatedAed = electorDocuments.first { aed -> // Get the new AED that this test would have created
+            contentDisposition.filename == "anonymous-elector-document-${aed.certificateNumber}.pdf"
+        }
+        assertThat(newlyCreatedAed)
+            .hasId()
+            .statusHistory {
+                it.hasSize(1)
+                it.hasStatus(AnonymousElectorDocumentStatus.Status.PRINTED)
+            }
+
+        PdfReader(pdfContent).use { reader ->
+            val text = PdfTextExtractor(reader).getTextFromPage(1)
+            assertThat(text).contains(newlyCreatedAed.certificateNumber)
+            assertThat(text).containsIgnoringCase(newElectoralRollNumber)
+            assertThat(text).doesNotContain(originalElectoralRollNumber)
+        }
+
+        await.pollDelay(3, TimeUnit.SECONDS).untilAsserted {
+            assertUpdateStatisticsMessageNotSent()
+        }
+    }
+
+    @Test
+    fun `should return AED PDF given specified application has multiple previously issued AED, including some with initial data removed`() {
+        // Given
+        val eroResponse = buildElectoralRegistrationOfficeResponse(
+            id = ERO_ID,
+            localAuthorities = listOf(buildLocalAuthorityResponse(gssCode = GSS_CODE), buildLocalAuthorityResponse())
+        )
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByEroId(eroResponse, ERO_ID)
+
+        val sourceReference = aValidSourceReference()
+        val photoLocationArn = addPhotoToS3()
+
+        val originalElectoralRollNumber = "ORIGINAL ELECTORAL ROLL #"
+
+        val oldPreviouslyIssuedAed = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            sourceReference = sourceReference,
+            photoLocationArn = photoLocationArn,
+            electoralRollNumber = originalElectoralRollNumber,
+        )
+        oldPreviouslyIssuedAed.removeInitialRetentionPeriodData()
+
+        val moreRecentAed = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            sourceReference = sourceReference,
+            photoLocationArn = photoLocationArn,
+            electoralRollNumber = originalElectoralRollNumber,
+        )
+        anonymousElectorDocumentRepository.saveAll(listOf(oldPreviouslyIssuedAed, moreRecentAed))
 
         val newElectoralRollNumber = aValidElectoralRollNumber()
         val requestBody = buildReIssueAnonymousElectorDocumentRequest(


### PR DESCRIPTION
At present, AEDs past the initial data retention will show up on the GetAnonymousElectorDocument endpoint, but will cause errors as some of the fields are null. We can either exclude them from such endpoints or allow these fields to be null - excluding them is likely to be the simpler solution.

This is required now because if there are multiple reissues of a certificate, and some have been through initial data retention while others haven't, then currently attempting to view the AED on the Manage AEDs tab will cause an error.

This change also excludes AEDs that have been through initial data retention from being updated by the update endpoints, which is important as they could add back contact details that was deleted during initial data retention.

These AEDs are also excluded from the reissue endpoint and the photo endpoint, to prevent any errors, though this is probably less important.

In the future, we are likely to want to display AEDs beyond the 15 month period, all the way up to 10 years. That may require undoing some of this, but that won't be very difficult and it is too early to work out what the exact technical requirements will be.