### PR TITLE
EIP1-11169 store is from applications api on certificate in database

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
@@ -92,6 +92,12 @@ class Certificate(
     var finalRetentionRemovalDate: LocalDate? = null,
 
     /**
+     * Set to true when the certificate is associated with an application from the Applications API, rather than the
+     * legacy Voter Card Applications API
+     */
+    var isFromApplicationsApi: Boolean? = false,
+
+    /**
      * Certificate status corresponds to the current status of the most recent
      * [PrintRequest], based on the requestDateTime that is included in the
      * [uk.gov.dluhc.printapi.messaging.models.SendApplicationToPrintMessage].

--- a/src/main/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintRequestBatchMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintRequestBatchMessageListener.kt
@@ -24,7 +24,10 @@ class ProcessPrintRequestBatchMessageListener(
 
             val certificates = processPrintBatchService.processBatch(batchId, printRequestCount)
             certificates.forEach {
-                statisticsUpdateService.updateStatistics(it.sourceReference!!, payload.isFromApplicationsApi)
+                statisticsUpdateService.updateStatistics(
+                    it.sourceReference!!,
+                    it.isFromApplicationsApi == true
+                )
             }
 
             logger.info("Successfully processed print request for batchId: $batchId")

--- a/src/main/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintRequestBatchMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintRequestBatchMessageListener.kt
@@ -24,10 +24,7 @@ class ProcessPrintRequestBatchMessageListener(
 
             val certificates = processPrintBatchService.processBatch(batchId, printRequestCount)
             certificates.forEach {
-                statisticsUpdateService.updateStatistics(
-                    it.sourceReference!!,
-                    it.isFromApplicationsApi == true
-                )
+                statisticsUpdateService.updateStatistics(it.sourceReference!!, it.isFromApplicationsApi)
             }
 
             logger.info("Successfully processed print request for batchId: $batchId")

--- a/src/main/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintResponseFileMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintResponseFileMessageListener.kt
@@ -22,7 +22,7 @@ class ProcessPrintResponseFileMessageListener(
     override fun handleMessage(@Payload payload: ProcessPrintResponseFileMessage) {
         with(payload) {
             logger.info { "Begin processing PrintResponse file [$fileName] from directory [$directory]" }
-            printResponseFileService.processPrintResponseFile(directory, fileName, payload.isFromApplicationsApi)
+            printResponseFileService.processPrintResponseFile(directory, fileName)
             logger.info { "Completed processing PrintResponse file [$fileName] from directory [$directory]" }
         }
     }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintResponseMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintResponseMessageListener.kt
@@ -24,7 +24,7 @@ class ProcessPrintResponseMessageListener(
     override fun handleMessage(@Payload payload: ProcessPrintResponseMessage) {
         logger.info { "Begin processing PrintResponse with requestId ${payload.requestId}" }
         printResponseProcessingService.processPrintResponse(payload)?.also {
-            statisticsUpdateService.updateStatistics(it.sourceReference!!, payload.isFromApplicationsApi)
+            statisticsUpdateService.updateStatistics(it.sourceReference!!, it.isFromApplicationsApi)
         }
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/messaging/service/PrintResponseFileService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/messaging/service/PrintResponseFileService.kt
@@ -16,7 +16,7 @@ class PrintResponseFileService(
     val printResponseProcessingService: PrintResponseProcessingService,
     val statisticsUpdateService: StatisticsUpdateService,
 ) {
-    fun processPrintResponseFile(directory: String, fileName: String, isFromApplicationsApi: Boolean? = null) {
+    fun processPrintResponseFile(directory: String, fileName: String) {
         val printResponsesString = sftpService.fetchFileFromOutBoundDirectory(directory, fileName)
         val printResponses = parsePrintResponseContent(printResponsesString)
         val certificates = printResponseProcessingService.processBatchResponses(printResponses.batchResponses)
@@ -24,7 +24,7 @@ class PrintResponseFileService(
         removeFile(directory, fileName)
 
         certificates.forEach {
-            statisticsUpdateService.updateStatistics(it.sourceReference!!, isFromApplicationsApi)
+            statisticsUpdateService.updateStatistics(it.sourceReference!!, it.isFromApplicationsApi)
         }
     }
 

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -38,4 +38,5 @@
     <include relativeToChangelogFile="true" file="ddl/0028_alter_aed_contact_details_add_last_updated.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0029_alter_print_request_add_sanitized_surname.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0030_add_index_for_source_reference_to_certificate_and_temporary_certificate.xml"/>
+    <include relativeToChangelogFile="true" file="ddl/0031_EIP1-11169_add_is_from_applications_api_to_certificate.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0031_EIP1-11169_add_is_from_applications_api_to_certificate.xml
+++ b/src/main/resources/db/changelog/ddl/0031_EIP1-11169_add_is_from_applications_api_to_certificate.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet id="0031_EIP1-11169_add_is_from_applications_api_to_certificate" author="david.rendell@softwire.com" context="ddl">
+        <addColumn tableName="certificate">
+            <column name="is_from_applications_api" type="boolean">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+        <rollback>
+            <dropColumn tableName="certificate" columnName="is_from_applications_api"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print API SQS Message Types
-  version: '1.9.6'
+  version: '1.10.0'
   description: |-
     Print API SQS Message Types
     
@@ -148,7 +148,7 @@ components:
           example: fred.bloggs@some-domain.co.uk
         isFromApplicationsApi:
           type: boolean
-          description: It indicates that the message comes from Applications Api or not
+          description: It indicates that the message comes from the Applications Api or the legacy Voter Card Applications API
       required:
         - sourceReference
         - sourceType
@@ -326,9 +326,6 @@ components:
         printRequestCount:
           type: integer
           description: The number of print requests included in the batch
-        isFromApplicationsApi:
-          type: boolean
-          description: It indicates that the message comes from Applications Api or not
       required:
         - batchId
 
@@ -342,9 +339,6 @@ components:
         fileName:
           type: string
           description: The file name to be processed
-        isFromApplicationsApi:
-          type: boolean
-          description: It indicates that the message comes from Applications Api or not
       required:
         - directory
         - fileName
@@ -382,9 +376,6 @@ components:
           type: string
           maxLength: 255
           description: Error description. Only populated if `status` is `FAILED`
-        isFromApplicationsApi:
-          type: boolean
-          description: It indicates that the message comes from Applications Api or not
       required:
         - requestId
         - timestamp

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintRequestBatchMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintRequestBatchMessageListenerIntegrationTest.kt
@@ -70,7 +70,8 @@ internal class ProcessPrintRequestBatchMessageListenerIntegrationTest : Integrat
                         )
                     )
                 )
-            )
+            ),
+            isFromApplicationsApi = isFromApplicationsApi
         )
         certificate = certificateRepository.save(certificate)
         TestTransaction.flagForCommit()
@@ -79,7 +80,7 @@ internal class ProcessPrintRequestBatchMessageListenerIntegrationTest : Integrat
         assertThat(filterListForName(batchId)).isEmpty()
 
         // add message to queue for processing
-        val payload = buildProcessPrintRequestBatchMessage(batchId = batchId, isFromApplicationsApi = isFromApplicationsApi)
+        val payload = buildProcessPrintRequestBatchMessage(batchId = batchId)
 
         // When
         TestTransaction.start()

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintResponseFileMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintResponseFileMessageListenerIntegrationTest.kt
@@ -2,8 +2,6 @@ package uk.gov.dluhc.printapi.messaging
 
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
-import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.NullSource
@@ -15,14 +13,12 @@ import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildCertificate
 import uk.gov.dluhc.printapi.testsupport.testdata.model.buildPrintResponses
 import java.util.concurrent.TimeUnit
 
-@TestInstance(Lifecycle.PER_CLASS)
 internal class ProcessPrintResponseFileMessageListenerIntegrationTest : IntegrationTest() {
 
-    // @Test
     @ParameterizedTest
     @NullSource
     @CsvSource("true", "false")
-    fun `should fetch remote print response file and send message to application api`(isFromApplicationsApi: Boolean?) {
+    fun `should fetch remote print response file and send message to source api`(isFromApplicationsApi: Boolean?) {
         // Given
         val filenameToProcess = "status-20220928235441999.json"
         val printResponses = buildPrintResponses()
@@ -31,7 +27,8 @@ internal class ProcessPrintResponseFileMessageListenerIntegrationTest : Integrat
         val certificates = printResponses.batchResponses.map {
             buildCertificate(
                 status = PrintRequestStatus.Status.SENT_TO_PRINT_PROVIDER,
-                batchId = it.batchId
+                batchId = it.batchId,
+                isFromApplicationsApi = isFromApplicationsApi
             )
         }
         certificateRepository.saveAll(certificates)
@@ -41,7 +38,6 @@ internal class ProcessPrintResponseFileMessageListenerIntegrationTest : Integrat
         val message = ProcessPrintResponseFileMessage(
             directory = PRINT_RESPONSE_DOWNLOAD_PATH,
             fileName = filenameToProcess,
-            isFromApplicationsApi = isFromApplicationsApi,
         )
 
         // When

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintResponseMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintResponseMessageListenerIntegrationTest.kt
@@ -49,7 +49,8 @@ internal class ProcessPrintResponseMessageListenerIntegrationTest : IntegrationT
                         )
                     )
                 )
-            )
+            ),
+            isFromApplicationsApi = isFromApplicationsApi
         )
         certificateRepository.save(certificate)
 
@@ -65,7 +66,6 @@ internal class ProcessPrintResponseMessageListenerIntegrationTest : IntegrationT
             status = ProcessPrintResponseMessage.Status.SUCCESS,
             statusStep = ProcessPrintResponseMessage.StatusStep.IN_MINUS_PRODUCTION,
             message = printResponse.message,
-            isFromApplicationsApi = isFromApplicationsApi
         )
 
         // When

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateBuilder.kt
@@ -70,6 +70,7 @@ fun buildCertificate(
     initialRetentionRemovalDate: LocalDate? = null,
     initialRetentionDataRemoved: Boolean = false,
     finalRetentionRemovalDate: LocalDate? = null,
+    isFromApplicationsApi: Boolean? = null,
 ): Certificate {
     val certificate = Certificate(
         id = if (persisted) randomUUID() else null,
@@ -89,6 +90,7 @@ fun buildCertificate(
         finalRetentionRemovalDate = finalRetentionRemovalDate,
         dateCreated = if (persisted) Instant.now() else null,
         createdBy = if (persisted) "system" else null,
+        isFromApplicationsApi = isFromApplicationsApi,
     )
     printRequests.forEach { printRequest -> certificate.addPrintRequest(printRequest) }
     return certificate

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/messaging/model/ProcessPrintRequestBatchMessageBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/messaging/model/ProcessPrintRequestBatchMessageBuilder.kt
@@ -5,8 +5,6 @@ import uk.gov.dluhc.printapi.testsupport.testdata.aValidBatchId
 
 fun buildProcessPrintRequestBatchMessage(
     batchId: String = aValidBatchId(),
-    isFromApplicationsApi: Boolean? = null,
 ) = ProcessPrintRequestBatchMessage(
     batchId = batchId,
-    isFromApplicationsApi = isFromApplicationsApi,
 )


### PR DESCRIPTION
## Describe your changes

Update the Print API to persist whether a certificate was generated for an application in the applications API or VAC.

Update the batch job to use that flag to pick the right statistics queue

Remove the isApplicationsApi flag from internal messages where it's unused.

## Issue ticket number and link

https://dluhcdigital.atlassian.net/browse/EIP1-11169

## Checklist before requesting a review

- [ ] I double checked that ACs on the ticket are met by this code update
- [ ] I have added testing steps to the ticket
- [ ] I have updated the relevant yml versions
- [ ] I have formatted the code
- [ ] I have added tests to new code and updated existing tests where needed
- [ ] I have added any corresponding changes to the UI portal

## Additional notes
