### PR TITLE
EROPSPT-397: Return AEDs post-initial retention period for AED search endpoint

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,7 +33,7 @@ jobs:
         run: ./gradlew clean check --no-daemon
 
       - name: Save logs on test failure
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Test logs

--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -80,7 +80,7 @@ jobs:
                 --data '@slack-notification.json' \
                 ${SLACK_WEBHOOK_URL}
       - name: Save logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Dependency Analysis Logs
           path: | 

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AnonymousElectorDocumentSummary.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AnonymousElectorDocumentSummary.kt
@@ -45,7 +45,7 @@ class AnonymousElectorDocumentSummary(
 
     val sanitizedSurname: String,
 
-    val postcode: String
+    val postcode: String?
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AnonymousElectorDocumentSummary.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AnonymousElectorDocumentSummary.kt
@@ -45,7 +45,9 @@ class AnonymousElectorDocumentSummary(
 
     val sanitizedSurname: String,
 
-    val postcode: String?
+    val postcode: String?,
+
+    val initialRetentionDataRemoved: Boolean
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/uk/gov/dluhc/printapi/dto/aed/AnonymousSearchSummaryResults.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/dto/aed/AnonymousSearchSummaryResults.kt
@@ -22,4 +22,5 @@ data class AnonymousSearchSummaryDto(
     val postcode: String?,
     val issueDate: LocalDate,
     val dateTimeCreated: Instant,
+    val initialRetentionDataRemoved: Boolean
 )

--- a/src/main/kotlin/uk/gov/dluhc/printapi/dto/aed/AnonymousSearchSummaryResults.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/dto/aed/AnonymousSearchSummaryResults.kt
@@ -19,7 +19,7 @@ data class AnonymousSearchSummaryDto(
     val electoralRollNumber: String,
     val firstName: String,
     val surname: String,
-    val postcode: String,
+    val postcode: String?,
     val issueDate: LocalDate,
     val dateTimeCreated: Instant,
 )

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/aed/AnonymousSearchSummaryMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/aed/AnonymousSearchSummaryMapper.kt
@@ -6,7 +6,6 @@ import uk.gov.dluhc.printapi.dto.aed.AnonymousSearchSummaryDto
 import uk.gov.dluhc.printapi.dto.aed.AnonymousSearchSummaryResults
 import uk.gov.dluhc.printapi.mapper.InstantMapper
 import uk.gov.dluhc.printapi.models.AedSearchSummaryResponse
-import uk.gov.dluhc.printapi.models.AnonymousElectorDocumentStatus
 import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocumentSummary as AnonymousElectorDocumentSummaryEntity
 import uk.gov.dluhc.printapi.models.AedSearchSummary as AedSearchSummaryApi
 
@@ -18,12 +17,6 @@ abstract class AnonymousSearchSummaryMapper {
 
     abstract fun toAedSearchSummaryResponse(aedSummaryResultsDto: AnonymousSearchSummaryResults): AedSearchSummaryResponse
 
-    @Mapping(target = "status", expression = "java(determineAedSummaryStatusBasedOnPostcode(dto))")
+    @Mapping(target = "status", expression = "java(dto.getInitialRetentionDataRemoved() ? AnonymousElectorDocumentStatus.EXPIRED : AnonymousElectorDocumentStatus.PRINTED)")
     protected abstract fun toAedSearchSummaryApi(dto: AnonymousSearchSummaryDto): AedSearchSummaryApi
-
-    protected fun determineAedSummaryStatusBasedOnPostcode(dto: AnonymousSearchSummaryDto) = if (dto.postcode != null) {
-        AnonymousElectorDocumentStatus.PRINTED
-    } else {
-        AnonymousElectorDocumentStatus.EXPIRED
-    }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/aed/AnonymousSearchSummaryMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/aed/AnonymousSearchSummaryMapper.kt
@@ -6,6 +6,7 @@ import uk.gov.dluhc.printapi.dto.aed.AnonymousSearchSummaryDto
 import uk.gov.dluhc.printapi.dto.aed.AnonymousSearchSummaryResults
 import uk.gov.dluhc.printapi.mapper.InstantMapper
 import uk.gov.dluhc.printapi.models.AedSearchSummaryResponse
+import uk.gov.dluhc.printapi.models.AnonymousElectorDocumentStatus
 import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocumentSummary as AnonymousElectorDocumentSummaryEntity
 import uk.gov.dluhc.printapi.models.AedSearchSummary as AedSearchSummaryApi
 
@@ -17,6 +18,12 @@ abstract class AnonymousSearchSummaryMapper {
 
     abstract fun toAedSearchSummaryResponse(aedSummaryResultsDto: AnonymousSearchSummaryResults): AedSearchSummaryResponse
 
-    @Mapping(target = "status", constant = "PRINTED")
+    @Mapping(target = "status", expression = "java(determineAedSummaryStatusBasedOnPostcode(dto))")
     protected abstract fun toAedSearchSummaryApi(dto: AnonymousSearchSummaryDto): AedSearchSummaryApi
+
+    protected fun determineAedSummaryStatusBasedOnPostcode(dto: AnonymousSearchSummaryDto) = if (dto.postcode != null) {
+        AnonymousElectorDocumentStatus.PRINTED
+    } else {
+        AnonymousElectorDocumentStatus.EXPIRED
+    }
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -39,4 +39,5 @@
     <include relativeToChangelogFile="true" file="ddl/0029_alter_print_request_add_sanitized_surname.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0030_add_index_for_source_reference_to_certificate_and_temporary_certificate.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0031_EIP1-11169_add_is_from_applications_api_to_certificate.xml"/>
+    <include relativeToChangelogFile="true" file="ddl/0032_EROPSPT-397_update_aed_summary_view_include_aeds_after_15_months.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0032_EROPSPT-397_update_aed_summary_view_include_aeds_after_15_months.xml
+++ b/src/main/resources/db/changelog/ddl/0032_EROPSPT-397_update_aed_summary_view_include_aeds_after_15_months.xml
@@ -22,7 +22,8 @@
             contact.first_name,
             contact.surname,
             contact.sanitized_surname,
-            addr.postcode
+            addr.postcode,
+            aed.initial_retention_data_removed
             FROM anonymous_elector_document aed
             JOIN aed_contact_details contact ON aed.aed_contact_details_id = contact.id
             LEFT JOIN address addr on contact.address_id = addr.id

--- a/src/main/resources/db/changelog/ddl/0032_EROPSPT-397_update_aed_summary_view_include_aeds_after_15_months.xml
+++ b/src/main/resources/db/changelog/ddl/0032_EROPSPT-397_update_aed_summary_view_include_aeds_after_15_months.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet id="0032_EROPSPT-397_update_aed_summary_view_include_aeds_after_15_months" author="alex.yip@softwire.com" context="ddl">
+        <comment>Include AEDs after initial retention period</comment>
+        <createView viewName="v_anonymous_elector_document_summary" replaceIfExists = "true">
+            SELECT
+            aed.id,
+            aed.gss_code,
+            aed.source_type,
+            aed.electoral_roll_number,
+            aed.sanitized_electoral_roll_number,
+            aed.certificate_number,
+            aed.source_reference,
+            aed.application_reference,
+            aed.issue_date,
+            aed.date_created,
+            contact.first_name,
+            contact.surname,
+            contact.sanitized_surname,
+            addr.postcode
+            FROM anonymous_elector_document aed
+            JOIN aed_contact_details contact ON aed.aed_contact_details_id = contact.id
+            LEFT JOIN address addr on contact.address_id = addr.id
+            JOIN (
+                    SELECT
+                        gss_code,
+                        source_type,
+                        source_reference,
+                        max(request_date_time) as most_recent_aed_request_date_time
+                    FROM anonymous_elector_document
+                    GROUP BY gss_code, source_type, source_reference
+                ) latest_aed_records_per_source_reference
+            ON aed.gss_code = latest_aed_records_per_source_reference.gss_code
+            AND aed.source_type = latest_aed_records_per_source_reference.source_type
+            AND aed.source_reference = latest_aed_records_per_source_reference.source_reference
+            AND aed.request_date_time = latest_aed_records_per_source_reference.most_recent_aed_request_date_time
+        </createView>
+
+        <rollback>
+            <comment>Reverting to the previous version of Anonymous Elector Document summary view</comment>
+            <createView viewName="v_anonymous_elector_document_summary" replaceIfExists = "true">
+                SELECT
+                aed.id,
+                aed.gss_code,
+                aed.source_type,
+                aed.electoral_roll_number,
+                aed.sanitized_electoral_roll_number,
+                aed.certificate_number,
+                aed.source_reference,
+                aed.application_reference,
+                aed.issue_date,
+                aed.date_created,
+                contact.first_name,
+                contact.surname,
+                contact.sanitized_surname,
+                addr.postcode
+                FROM anonymous_elector_document aed
+                JOIN aed_contact_details contact ON aed.aed_contact_details_id = contact.id
+                JOIN address addr on contact.address_id = addr.id
+                JOIN (
+                        SELECT
+                            gss_code,
+                            source_type,
+                            source_reference,
+                            max(request_date_time) as most_recent_aed_request_date_time
+                        FROM anonymous_elector_document
+                        GROUP BY gss_code, source_type, source_reference
+                    ) latest_aed_records_per_source_reference
+                ON aed.gss_code = latest_aed_records_per_source_reference.gss_code
+                AND aed.source_type = latest_aed_records_per_source_reference.source_type
+                AND aed.source_reference = latest_aed_records_per_source_reference.source_reference
+                AND aed.request_date_time = latest_aed_records_per_source_reference.most_recent_aed_request_date_time
+        </createView>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print APIs
-  version: '1.23.2'
+  version: '1.23.3'
   description: Print APIs
 #
 # --------------------------------------------------------------------------------
@@ -1893,7 +1893,7 @@ components:
           example: Blogs
         postcode:
           type: string
-          description: The applicant's postcode
+          description: The applicant's postcode. A null postcode indicates that the AED has passed it's initial retention period.
           example: AA1 1AA
         issueDate:
           type: string
@@ -1914,7 +1914,6 @@ components:
         - status
         - firstName
         - surname
-        - postcode
         - issueDate
         - dateTimeCreated
 

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -1818,6 +1818,7 @@ components:
       enum:
         - generated
         - printed
+        - expired
 
     AedSearchSummaryResponse:
       title: AedSearchSummaryResponse

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -1894,7 +1894,7 @@ components:
           example: Blogs
         postcode:
           type: string
-          description: The applicant's postcode. A null postcode indicates that the AED has passed it's initial retention period.
+          description: The applicant's postcode. A null postcode indicates that the AED has passed its initial retention period.
           example: AA1 1AA
         issueDate:
           type: string

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/aed/AnonymousSearchSummaryMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/aed/AnonymousSearchSummaryMapperTest.kt
@@ -118,9 +118,9 @@ class AnonymousSearchSummaryMapperTest {
     }
 
     @Test
-    fun `should map AnonymousSearchSummaryDto with null postcode to an AedSearchSummary Api`() {
+    fun `should map AnonymousSearchSummaryDto with initialRetentionDataRemoved to an AedSearchSummary Api`() {
         // Given
-        val dto = buildAnonymousSearchSummaryDto(postcode = null)
+        val dto = buildAnonymousSearchSummaryDto(postcode = null, initialRetentionDataRemoved = true)
         val expectedOffsetDateTime = OffsetDateTime.now()
 
         given(instantMapper.toOffsetDateTime(any())).willReturn(expectedOffsetDateTime)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/SearchAedSummariesIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/SearchAedSummariesIntegrationTest.kt
@@ -9,6 +9,7 @@ import uk.gov.dluhc.printapi.models.AedSearchBy
 import uk.gov.dluhc.printapi.models.AedSearchBy.APPLICATION_REFERENCE
 import uk.gov.dluhc.printapi.models.AedSearchBy.SURNAME
 import uk.gov.dluhc.printapi.models.AedSearchSummaryResponse
+import uk.gov.dluhc.printapi.models.AnonymousElectorDocumentStatus
 import uk.gov.dluhc.printapi.testsupport.bearerToken
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidApplicationReference
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
@@ -305,6 +306,78 @@ internal class SearchAedSummariesIntegrationTest : IntegrationTest() {
             .usingRecursiveComparison()
             .ignoringFieldsMatchingRegexes(".*dateTimeCreated")
             .isEqualTo(expectedResults)
+    }
+
+    @Test
+    fun `should return all summaries including AEDs passed the initial retention period`() {
+        // Given
+        val eroResponse = buildElectoralRegistrationOfficeResponse(
+            id = ERO_ID,
+            localAuthorities = listOf(buildLocalAuthorityResponse(gssCode = GSS_CODE))
+        )
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByEroId(eroResponse, ERO_ID)
+
+        val currentDate = LocalDate.now()
+        val currentDateTimeInstant = Instant.now()
+
+        val aed1SourceReference = aValidSourceReference()
+        val aed1ApplicationReference = aValidApplicationReference()
+        val application1AedPassedInitialRetentionPeriod = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            sourceReference = aed1SourceReference,
+            applicationReference = aed1ApplicationReference,
+            issueDate = currentDate.minusDays(10),
+            requestDateTime = currentDateTimeInstant.minusSeconds(10),
+            surname = "AAA",
+        )
+        val application1LatestAed = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            sourceReference = aed1SourceReference,
+            applicationReference = aed1ApplicationReference,
+            issueDate = currentDate.minusDays(9),
+            requestDateTime = currentDateTimeInstant, // View will return this latest record as it has latest requestDateTime
+            contactDetails = application1AedPassedInitialRetentionPeriod.contactDetails!!
+        )
+
+        application1AedPassedInitialRetentionPeriod.removeInitialRetentionPeriodData()
+
+        val application2AedDocument = buildAnonymousElectorDocument(gssCode = GSS_CODE, issueDate = currentDate)
+
+        anonymousElectorDocumentRepository.saveAll(
+            listOf(application1AedPassedInitialRetentionPeriod, application1LatestAed, application2AedDocument)
+        )
+
+        val expectedSummaryRecord2 = buildAedSearchSummaryApiFromAedEntity(application2AedDocument)
+        val expectedSummaryRecord3 = buildAedSearchSummaryApiFromAedEntity(
+            application1LatestAed,
+            status = AnonymousElectorDocumentStatus.EXPIRED
+        )
+        val expectedResultsInExactOrder = listOf(expectedSummaryRecord2, expectedSummaryRecord3)
+
+        // When
+        val response = webTestClient.get()
+            .uri(buildUri(uriTemplate = SEARCH_SUMMARY_URI_TEMPLATE, eroId = ERO_ID))
+            .bearerToken(getVCAnonymousAdminBearerToken(eroId = ERO_ID))
+            .contentType(APPLICATION_JSON)
+            .exchange()
+            .expectStatus().isOk
+            .returnResult(AedSearchSummaryResponse::class.java)
+
+        // Then
+        val actual = response.responseBody.blockFirst()
+        assertThat(actual).isNotNull
+        with(actual!!) {
+            assertThat(page).isEqualTo(1)
+            assertThat(pageSize).isEqualTo(100)
+            assertThat(totalPages).isEqualTo(1)
+            assertThat(totalResults).isEqualTo(2)
+            assertThat(results).isNotEmpty
+                .hasSize(2)
+                .usingRecursiveComparison()
+                .ignoringFieldsMatchingRegexes(".*dateTimeCreated")
+                .isEqualTo(expectedResultsInExactOrder)
+        }
     }
 
     private fun buildUri(

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/SearchAedSummariesIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/SearchAedSummariesIntegrationTest.kt
@@ -330,30 +330,20 @@ internal class SearchAedSummariesIntegrationTest : IntegrationTest() {
             issueDate = currentDate.minusDays(10),
             requestDateTime = currentDateTimeInstant.minusSeconds(10),
             surname = "AAA",
-        )
-        val application1LatestAed = buildAnonymousElectorDocument(
-            gssCode = GSS_CODE,
-            sourceReference = aed1SourceReference,
-            applicationReference = aed1ApplicationReference,
-            issueDate = currentDate.minusDays(9),
-            requestDateTime = currentDateTimeInstant, // View will return this latest record as it has latest requestDateTime
-            contactDetails = application1AedPassedInitialRetentionPeriod.contactDetails!!
-        )
-
-        application1AedPassedInitialRetentionPeriod.removeInitialRetentionPeriodData()
+        ).also { it.removeInitialRetentionPeriodData() }
 
         val application2AedDocument = buildAnonymousElectorDocument(gssCode = GSS_CODE, issueDate = currentDate)
 
         anonymousElectorDocumentRepository.saveAll(
-            listOf(application1AedPassedInitialRetentionPeriod, application1LatestAed, application2AedDocument)
+            listOf(application1AedPassedInitialRetentionPeriod, application2AedDocument)
         )
 
-        val expectedSummaryRecord2 = buildAedSearchSummaryApiFromAedEntity(application2AedDocument)
-        val expectedSummaryRecord3 = buildAedSearchSummaryApiFromAedEntity(
-            application1LatestAed,
+        val expectedSummaryRecord1 = buildAedSearchSummaryApiFromAedEntity(application2AedDocument)
+        val expectedSummaryRecord2 = buildAedSearchSummaryApiFromAedEntity(
+            application1AedPassedInitialRetentionPeriod,
             status = AnonymousElectorDocumentStatus.EXPIRED
         )
-        val expectedResultsInExactOrder = listOf(expectedSummaryRecord2, expectedSummaryRecord3)
+        val expectedResultsInExactOrder = listOf(expectedSummaryRecord1, expectedSummaryRecord2)
 
         // When
         val response = webTestClient.get()

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/aed/AnonymousSearchSummaryDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/aed/AnonymousSearchSummaryDtoBuilder.kt
@@ -25,6 +25,7 @@ fun buildAnonymousSearchSummaryDto(
     firstName: String = aValidFirstName(),
     surname: String = aValidSurname(),
     postcode: String? = faker.address().postcode(),
+    initialRetentionDataRemoved: Boolean = false,
 ): AnonymousSearchSummaryDto {
     return AnonymousSearchSummaryDto(
         gssCode = gssCode,
@@ -36,6 +37,7 @@ fun buildAnonymousSearchSummaryDto(
         dateTimeCreated = dateTimeCreated,
         firstName = firstName,
         surname = surname,
-        postcode = postcode
+        postcode = postcode,
+        initialRetentionDataRemoved = initialRetentionDataRemoved
     )
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/aed/AnonymousSearchSummaryDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/aed/AnonymousSearchSummaryDtoBuilder.kt
@@ -24,7 +24,7 @@ fun buildAnonymousSearchSummaryDto(
     dateTimeCreated: Instant = aValidRequestDateTime(),
     firstName: String = aValidFirstName(),
     surname: String = aValidSurname(),
-    postcode: String = faker.address().postcode(),
+    postcode: String? = faker.address().postcode(),
 ): AnonymousSearchSummaryDto {
     return AnonymousSearchSummaryDto(
         gssCode = gssCode,

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/AnonymousElectorDocumentSummaryBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/AnonymousElectorDocumentSummaryBuilder.kt
@@ -1,6 +1,5 @@
 package uk.gov.dluhc.printapi.testsupport.testdata.entity
 
-import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocument
 import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocumentSummary
 import uk.gov.dluhc.printapi.database.entity.SourceType
 import uk.gov.dluhc.printapi.testsupport.buildSanitizedSurname
@@ -31,7 +30,7 @@ fun buildAnonymousElectorDocumentSummaryEntity(
     dateCreated: Instant = aValidRequestDateTime(),
     firstName: String = aValidFirstName(),
     surname: String = aValidSurname(),
-    postcode: String = faker.address().postcode(),
+    postcode: String? = faker.address().postcode(),
 ): AnonymousElectorDocumentSummary {
     return AnonymousElectorDocumentSummary(
         id = id,
@@ -49,29 +48,4 @@ fun buildAnonymousElectorDocumentSummaryEntity(
         sanitizedSurname = buildSanitizedSurname(surname),
         postcode = postcode
     )
-}
-
-fun buildAnonymousElectorDocumentSummaryViewFromAedEntity(
-    aedEntity: AnonymousElectorDocument,
-    electoralRollNumber: String = aedEntity.electoralRollNumber,
-    surname: String = aedEntity.contactDetails!!.surname
-): AnonymousElectorDocumentSummary {
-    return with(aedEntity) {
-        AnonymousElectorDocumentSummary(
-            id = id!!,
-            gssCode = gssCode,
-            sourceType = sourceType,
-            sourceReference = sourceReference,
-            applicationReference = applicationReference,
-            certificateNumber = certificateNumber,
-            electoralRollNumber = electoralRollNumber,
-            sanitizedElectoralRollNumber = electoralRollNumber,
-            firstName = contactDetails!!.firstName,
-            surname = surname,
-            sanitizedSurname = buildSanitizedSurname(surname),
-            postcode = contactDetails!!.address!!.postcode!!,
-            issueDate = issueDate,
-            dateCreated = requestDateTime
-        )
-    }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/AnonymousElectorDocumentSummaryBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/AnonymousElectorDocumentSummaryBuilder.kt
@@ -31,6 +31,7 @@ fun buildAnonymousElectorDocumentSummaryEntity(
     firstName: String = aValidFirstName(),
     surname: String = aValidSurname(),
     postcode: String? = faker.address().postcode(),
+    initialRetentionDataRemoved: Boolean = false,
 ): AnonymousElectorDocumentSummary {
     return AnonymousElectorDocumentSummary(
         id = id,
@@ -46,6 +47,7 @@ fun buildAnonymousElectorDocumentSummaryEntity(
         firstName = firstName,
         surname = surname,
         sanitizedSurname = buildSanitizedSurname(surname),
-        postcode = postcode
+        postcode = postcode,
+        initialRetentionDataRemoved = initialRetentionDataRemoved
     )
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/AedSummaryBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/AedSummaryBuilder.kt
@@ -29,7 +29,7 @@ fun buildAedSearchSummaryApi(
     dateTimeCreated: OffsetDateTime = aValidGeneratedDateTime(),
     firstName: String = aValidFirstName(),
     surname: String = aValidSurname(),
-    postcode: String = faker.address().postcode(),
+    postcode: String? = faker.address().postcode(),
 ): AedSearchSummary {
     return AedSearchSummary(
         gssCode = gssCode,
@@ -49,7 +49,8 @@ fun buildAedSearchSummaryApi(
 fun buildAedSearchSummaryApiFromAedEntity(
     aedEntity: AnonymousElectorDocument,
     electoralRollNumber: String = aedEntity.electoralRollNumber,
-    surname: String = aedEntity.contactDetails!!.surname
+    surname: String = aedEntity.contactDetails!!.surname,
+    status: AnonymousElectorDocumentStatus = AnonymousElectorDocumentStatus.PRINTED
 ): AedSearchSummary {
     return with(aedEntity) {
         AedSearchSummary(
@@ -58,12 +59,12 @@ fun buildAedSearchSummaryApiFromAedEntity(
             applicationReference = applicationReference,
             certificateNumber = certificateNumber,
             electoralRollNumber = electoralRollNumber,
-            status = AnonymousElectorDocumentStatus.PRINTED,
+            status = status,
             issueDate = issueDate,
             dateTimeCreated = requestDateTime.atOffset(ZoneOffset.UTC),
             firstName = contactDetails!!.firstName,
             surname = surname,
-            postcode = contactDetails!!.address!!.postcode!!
+            postcode = contactDetails?.address?.postcode
         )
     }
 }


### PR DESCRIPTION
## Describe your changes

To keep the PR small-ish, I'm splitting the changes up into multiple PRs. This one is for returning AEDs that have had their first retention period data removed when searched, i.e., showing it in the "Manage AEDs" page.

There will need to be changes to the UI as well, and further changes to the backend for the page that shows individual applications.

## Issue ticket number and link

https://mhclgdigital.atlassian.net/browse/EROPSPT-397

## Checklist before requesting a review

- [ ] I double checked that ACs on the ticket are met by this code update
- [ ] I have added testing steps to the ticket
- [ ] I have updated the relevant yml versions
- [ ] I have formatted the code
- [ ] I have added tests to new code and updated existing tests where needed
- [ ] I have added any corresponding changes to the UI portal

## Additional notes
