### PR TITLE
EROPSPT-443: Upgrade SB to 3.4.5 and dependency checker to 12.1.1, add suppression for CVE-2025-3588

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
 import java.lang.ProcessBuilder.Redirect
 
 plugins {
-    id("org.springframework.boot") version "3.4.4"
+    id("org.springframework.boot") version "3.4.5"
     id("io.spring.dependency-management") version "1.1.6"
     kotlin("jvm") version "1.9.25"
     kotlin("kapt") version "1.9.25"
@@ -16,7 +16,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
     id("org.jlleitschuh.gradle.ktlint-idea") version "11.0.0"
     id("org.openapi.generator") version "7.9.0"
-    id("org.owasp.dependencycheck") version "12.1.0"
+    id("org.owasp.dependencycheck") version "12.1.1"
     id("org.jsonschema2dataclass") version "6.0.0"
 }
 

--- a/owasp.suppressions.xml
+++ b/owasp.suppressions.xml
@@ -19,4 +19,22 @@
         <packageUrl regex="true">^pkg:maven/commons\-io/commons\-io@.*$</packageUrl>
         <vulnerabilityName>CVE-2024-47554</vulnerabilityName>
     </suppress>
+    <suppress until="2025-07-01Z">
+        <notes>
+            <![CDATA[file name: jsonschema2pojo-core-1.1.2.jar]]>
+
+            No available fix at the time of writing.
+
+            jsonschema2dataclass:6.0.0 imports jsonschema2pojo:1.1.2.
+
+            jsonschema2dataclass has not had a release since Jan 2023,
+            so the suppression date has been set until Q3 2025
+
+            The attack requires a maliciously crafted yaml spec,
+            which would require write access to the source code.
+            The inputs we provide do not result in this issue.
+        </notes>
+        <packageUrl regex="true">^pkg:maven/org\.jsonschema2pojo/jsonschema2pojo-core@.*$</packageUrl>
+        <vulnerabilityName>CVE-2025-3588</vulnerabilityName>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Upgrading to SB 3.4.5 resolves CVE-2025-22235 and CVE-2025-22234. It also resolve the dependency clash with dependency-checker 12.1.1, which fixes bugs present in older versions of the dependency checker.