### PR TITLE
EROPSPT-514: Remove code for legacy data retention period

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/config/DataRetentionConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/config/DataRetentionConfiguration.kt
@@ -7,5 +7,4 @@ import java.time.Period
 data class DataRetentionConfiguration(
     val certificateInitialRetentionPeriod: Period,
     val certificateRemovalBatchSize: Int,
-    val legacyCertificateInitialRetentionPeriod: Period,
 )

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
@@ -95,13 +95,6 @@ class Certificate(
     var hasSourceApplicationBeenRemoved: Boolean? = false,
 
     /**
-     * Temporary flag used to indicate whether the certificate was created after the rollout
-     *
-     * TODO EROPSPT-XXX: Remove this field once all certificates created before the rollout have been deleted
-     */
-    var isCertificateCreatedWithPrinterProvidedIssueDate: Boolean? = true,
-
-    /**
      * Certificate status corresponds to the current status of the most recent
      * [PrintRequest], based on the requestDateTime that is included in the
      * [uk.gov.dluhc.printapi.messaging.models.SendApplicationToPrintMessage].

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateDataRetentionService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateDataRetentionService.kt
@@ -59,18 +59,13 @@ class CertificateDataRetentionService(
     }
 
     fun setCertificateRetentionRemovalDates(certificate: Certificate, gssCode: String): Certificate {
-        val issueDate = certificate.issueDate
-
-        if (issueDate == null) {
-            throw IllegalArgumentException("Issue date not found for certificate")
-        }
+        val issueDate = certificate.issueDate ?: throw IllegalArgumentException("Issue date not found for certificate")
 
         return certificate.also {
             it.initialRetentionRemovalDate =
                 removalDateResolver.getCertificateInitialRetentionPeriodRemovalDate(
                     issueDate,
                     gssCode,
-                    it.isCertificateCreatedWithPrinterProvidedIssueDate ?: false
                 )
             it.finalRetentionRemovalDate =
                 removalDateResolver.getElectorDocumentFinalRetentionPeriodRemovalDate(issueDate)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/ElectorDocumentRemovalDateResolver.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/ElectorDocumentRemovalDateResolver.kt
@@ -36,16 +36,8 @@ class ElectorDocumentRemovalDateResolver(
     fun getCertificateInitialRetentionPeriodRemovalDate(
         issueDate: LocalDate,
         gssCode: String,
-        isCertificateCreatedWithPrinterProvidedIssueDate: Boolean,
     ): LocalDate {
-        // This is a temporary workaround to ensure that applications created before EROPSPT-418 is deployed
-        // are retained for 29 (1 extra) working days.
-        // TODO EROPSPT-XXX: Remove this workaround once all applications created before EROPSPT-418 are removed
-        val requiredWorkingDays = if (isCertificateCreatedWithPrinterProvidedIssueDate) {
-            dataRetentionConfig.certificateInitialRetentionPeriod.days
-        } else {
-            dataRetentionConfig.legacyCertificateInitialRetentionPeriod.days
-        }
+        val requiredWorkingDays = dataRetentionConfig.certificateInitialRetentionPeriod.days
 
         val daysToAdd = getTotalDaysForWorkingDays(
             issueDate,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,8 +55,6 @@ api:
       valid-on-date:
         max-calendar-days-in-future: 30
     data-retention:
-      # TODO EROPSPT-XXX: Remove legacy period once all certificates created before rollout are removed
-      legacy-certificate-initial-retention-period: "P29D"
       certificate-initial-retention-period: "P28D"
       certificate-removal-batch-size: 10000
 

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -45,4 +45,5 @@
     <include relativeToChangelogFile="true" file="ddl/0035_EROPSPT-418_alter_certificate_to_use_printer_provided_issue_date.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0036_EIP1-11368_make_certificate_isFromApplicationsApi_default_true.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0037_EIP1-11368_remove_is_from_applications_api_from_certificate.xml"/>
+    <include relativeToChangelogFile="true" file="ddl/0038_EROPSPT-514_remove-temporary-certificate-printer-provided-flag.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0038_EROPSPT-514_remove-temporary-certificate-printer-provided-flag.xml
+++ b/src/main/resources/db/changelog/ddl/0038_EROPSPT-514_remove-temporary-certificate-printer-provided-flag.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet id="0038_EROPSPT-514_remove-temporary-certificate-printer-provided-flag"
+               author="alex.yip@softwire.com"
+               context="ddl">
+        <comment>
+            Remove temporary column is_certificate_created_with_printer_provided_issue_date.
+        </comment>
+
+        <dropColumn
+            tableName="certificate"
+            columnName="is_certificate_created_with_printer_provided_issue_date"
+        />
+
+        <rollback>
+            <addColumn tableName="certificate">
+                <column
+                    name="is_certificate_created_with_printer_provided_issue_date"
+                    type="boolean"
+                    defaultValue="false"
+                />
+            </addColumn>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateDataRetentionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateDataRetentionServiceTest.kt
@@ -72,7 +72,7 @@ internal class CertificateDataRetentionServiceTest {
             val expectedFinalRetentionRemovalDate = LocalDate.of(2032, JULY, 1)
             given(sourceTypeMapper.mapSqsToEntity(any())).willReturn(VOTER_CARD)
             given(certificateRepository.findByGssCodeAndSourceTypeAndSourceReference(any(), any(), any())).willReturn(certificate)
-            given(removalDateResolver.getCertificateInitialRetentionPeriodRemovalDate(any(), any(), any())).willReturn(expectedInitialRetentionRemovalDate)
+            given(removalDateResolver.getCertificateInitialRetentionPeriodRemovalDate(any(), any())).willReturn(expectedInitialRetentionRemovalDate)
             given(removalDateResolver.getElectorDocumentFinalRetentionPeriodRemovalDate(any())).willReturn(expectedFinalRetentionRemovalDate)
 
             // When
@@ -84,7 +84,7 @@ internal class CertificateDataRetentionServiceTest {
             assertThat(certificate.hasSourceApplicationBeenRemoved).isTrue
             verify(sourceTypeMapper).mapSqsToEntity(message.sourceType)
             verify(certificateRepository).findByGssCodeAndSourceTypeAndSourceReference(message.gssCode, VOTER_CARD, message.sourceReference)
-            verify(removalDateResolver).getCertificateInitialRetentionPeriodRemovalDate(certificate.issueDate!!, message.gssCode, true)
+            verify(removalDateResolver).getCertificateInitialRetentionPeriodRemovalDate(certificate.issueDate!!, message.gssCode)
             verify(removalDateResolver).getElectorDocumentFinalRetentionPeriodRemovalDate(certificate.issueDate!!)
             verify(certificateRepository).save(certificate)
         }
@@ -139,7 +139,7 @@ internal class CertificateDataRetentionServiceTest {
             assertThat(certificate.hasSourceApplicationBeenRemoved).isTrue
             verify(sourceTypeMapper).mapSqsToEntity(message.sourceType)
             verify(certificateRepository).findByGssCodeAndSourceTypeAndSourceReference(message.gssCode, VOTER_CARD, message.sourceReference)
-            verify(removalDateResolver, never()).getCertificateInitialRetentionPeriodRemovalDate(any(), any(), any())
+            verify(removalDateResolver, never()).getCertificateInitialRetentionPeriodRemovalDate(any(), any())
             verify(removalDateResolver, never()).getElectorDocumentFinalRetentionPeriodRemovalDate(any())
             verify(certificateRepository).save(certificate)
             assertThat(

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/ElectorDocumentRemovalDateResolverTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/ElectorDocumentRemovalDateResolverTest.kt
@@ -42,7 +42,7 @@ internal class ElectorDocumentRemovalDateResolverTest {
             given(bankHolidaysDataService.getUpcomingBankHolidays(any(), any(), any())).willReturn(listOf(upcomingBankHoliday))
 
             // When
-            val actual = electorDocumentRemovalDateResolver.getCertificateInitialRetentionPeriodRemovalDate(issueDate, gssCode, true)
+            val actual = electorDocumentRemovalDateResolver.getCertificateInitialRetentionPeriodRemovalDate(issueDate, gssCode)
 
             // Then
             assertThat(actual).isEqualTo(expectedRemovalDate)
@@ -60,7 +60,7 @@ internal class ElectorDocumentRemovalDateResolverTest {
             given(bankHolidaysDataService.getUpcomingBankHolidays(any(), any(), any())).willReturn(emptyList())
 
             // When
-            val actual = electorDocumentRemovalDateResolver.getCertificateInitialRetentionPeriodRemovalDate(issueDate, gssCode, true)
+            val actual = electorDocumentRemovalDateResolver.getCertificateInitialRetentionPeriodRemovalDate(issueDate, gssCode)
 
             // Then
             assertThat(actual).isEqualTo(expectedRemovalDate)


### PR DESCRIPTION
## Describe your changes

It's been more than 29 working days (and even more than that by the time we release this) since we released the VAC destruction work so the legacy 28 + 1 working day data retention period is now obsolete, since now VACs created before the change will be immediately delete when their source application gets deleted.

## Issue ticket number and link

https://dluhcdigital.atlassian.net/browse/EIP1-

## Checklist before requesting a review

- [ ] I double checked that ACs on the ticket are met by this code update
- [ ] I have checked any risky steps with my TL ([cheat sheet for safe release here](https://softwiretech.atlassian.net/wiki/spaces/EIP/pages/20960542739/Safe+Release+Cheat+Sheet))
- [ ] I have updated the relevant yml versions
- [ ] I have added tests to new code and updated existing tests where needed
- [ ] I have added any corresponding changes to the UI portal
- [ ] I have documented any release dependencies (e.g. service release order or incompatible versions) in the [Release notes](https://softwiretech.atlassian.net/wiki/spaces/EIP/pages/21254340716/Release+-+EROP+Version+-+Date+TBC)
    - Can leave tags as tbd until merged
